### PR TITLE
update course serializer to use 1 key for cutoffs

### DIFF
--- a/packages/course-serializer/__tests__/serializer-regression.spec.js
+++ b/packages/course-serializer/__tests__/serializer-regression.spec.js
@@ -9,9 +9,7 @@ describe('Regression > Course Serializer', function () {
 	it('v0', function () {
 		// We need to allow the version to come back as 0 since this is a regression test for that version
 		// Must create new object to make sure we don't affect other tests
-		const exampleCourse = require('../fixtures/example-serialized-course.json');
-		const exampleAsV0 = {...exampleCourse, version: 0};
-
-		expect(serializer.deserialize(SERIALIZED_V0_COURSE)).to.deep.equal(exampleAsV0);
+		const exampleCourse = require('../fixtures/v0-example-serialized-course.json');
+		expect(serializer.deserialize(SERIALIZED_V0_COURSE)).to.deep.equal(exampleCourse);
 	});
 });

--- a/packages/course-serializer/__tests__/serializer-regression.spec.js
+++ b/packages/course-serializer/__tests__/serializer-regression.spec.js
@@ -1,1 +1,17 @@
 // This file specifically tests deserialization across older versions
+
+const {expect} = require('chai');
+const serializer = require('../lib/commonjs/course-serializer');
+
+const SERIALIZED_V0_COURSE = 'eyJtIjoiMHwyMDIwfDB8OTB8ODB8NzB8NjB8QXxCfEN8RHxFeGFtcGxlIENvdXJzZSIsInoiOlsiMXwwfDIwfDB8QXR0ZW5kYW5jZSIsIjF8MHwxM3wxfE9ubGluZSBRdWl6emVzIiwiMXwwfDR8NXxDdWx0dXJhbCBEaXNjb3Vyc2UgSm91cm5hbCIsIjB8MHwxfDIwfEV4YW0gMSIsIjB8MHwxfDIwfEV4YW0gMiIsIjB8MHwxfDV8SW5pdGlhbCBFc3NheSIsIjB8MHwxfDE1fEZpbmFsIEVzc2F5IiwiMXwwfDJ8MTB8U2hvcnQgUGFwZXIiLCIwfDB8MXw1fFBhcnRpY2lwYXRpb24iLCIwfDB8MXw1fFByZXNlbnRhdGlvbiIsIjB8MHwxfDE1fE9ubGluZSBRdWl6emVzIGFmdGVyIGRyb3BwZWQiXX0=';
+
+describe('Regression > Course Serializer', function () {
+	it('v0', function () {
+		// We need to allow the version to come back as 0 since this is a regression test for that version
+		// Must create new object to make sure we don't affect other tests
+		const exampleCourse = require('../fixtures/example-serialized-course.json');
+		const exampleAsV0 = {...exampleCourse, version: 0};
+
+		expect(serializer.deserialize(SERIALIZED_V0_COURSE)).to.deep.equal(exampleAsV0);
+	});
+});

--- a/packages/course-serializer/__tests__/serializer.spec.js
+++ b/packages/course-serializer/__tests__/serializer.spec.js
@@ -5,7 +5,7 @@ const serializer = require('../lib/commonjs/course-serializer');
 const getSafeCourse = () => JSON.parse(JSON.stringify(require('../fixtures/example-serialized-course.json')));
 const getExampleCourse = () => JSON.parse(JSON.stringify(require('../fixtures/example-course.json')));
 
-const SERIALIZED_COURSE = 'eyJtIjoiMHwyMDIwfDB8OTB8ODB8NzB8NjB8QXxCfEN8RHxFeGFtcGxlIENvdXJzZSIsInoiOlsiMXwwfDIwfDB8QXR0ZW5kYW5jZSIsIjF8MHwxM3wxfE9ubGluZSBRdWl6emVzIiwiMXwwfDR8NXxDdWx0dXJhbCBEaXNjb3Vyc2UgSm91cm5hbCIsIjB8MHwxfDIwfEV4YW0gMSIsIjB8MHwxfDIwfEV4YW0gMiIsIjB8MHwxfDV8SW5pdGlhbCBFc3NheSIsIjB8MHwxfDE1fEZpbmFsIEVzc2F5IiwiMXwwfDJ8MTB8U2hvcnQgUGFwZXIiLCIwfDB8MXw1fFBhcnRpY2lwYXRpb24iLCIwfDB8MXw1fFByZXNlbnRhdGlvbiIsIjB8MHwxfDE1fE9ubGluZSBRdWl6emVzIGFmdGVyIGRyb3BwZWQiXX0=';
+const SERIALIZED_COURSE = 'eyJtIjoiMXwyMDIwfDB8NHxBLDkwfEIsODB8Qyw3MHxELDYwfEV4YW1wbGUgQ291cnNlIiwieiI6WyIxfDB8MjB8MHxBdHRlbmRhbmNlIiwiMXwwfDEzfDF8T25saW5lIFF1aXp6ZXMiLCIxfDB8NHw1fEN1bHR1cmFsIERpc2NvdXJzZSBKb3VybmFsIiwiMHwwfDF8MjB8RXhhbSAxIiwiMHwwfDF8MjB8RXhhbSAyIiwiMHwwfDF8NXxJbml0aWFsIEVzc2F5IiwiMHwwfDF8MTV8RmluYWwgRXNzYXkiLCIxfDB8MnwxMHxTaG9ydCBQYXBlciIsIjB8MHwxfDV8UGFydGljaXBhdGlvbiIsIjB8MHwxfDV8UHJlc2VudGF0aW9uIiwiMHwwfDF8MTV8T25saW5lIFF1aXp6ZXMgYWZ0ZXIgZHJvcHBlZCJdfQ==';
 
 describe('Unit > Serializer', function () {
 	it('strip properly removes PII from a category', function () {

--- a/packages/course-serializer/fixtures/example-course.json
+++ b/packages/course-serializer/fixtures/example-course.json
@@ -2,14 +2,12 @@
   "id": "5d5f61ecfa8fcd6565dea001",
   "semester": "2019F",
   "name": "Example Course",
-  "cut1": 90,
-  "cut2": 80,
-  "cut3": 70,
-  "cut4": 60,
-  "cut1Name": "A",
-  "cut2Name": "B",
-  "cut3Name": "C",
-  "cut4Name": "D",
+  "cutoffs": {
+    "A": 90,
+    "B": 80,
+    "C": 70,
+    "D": 60
+  },
   "credits": 0,
   "categories": [
     {

--- a/packages/course-serializer/fixtures/example-serialized-course.json
+++ b/packages/course-serializer/fixtures/example-serialized-course.json
@@ -1,15 +1,13 @@
 {
-  "version": 0,
+  "version": 1,
   "year": 2020,
   "credits": 0,
-  "cut1": 90,
-  "cut2": 80,
-  "cut3": 70,
-  "cut4": 60,
-  "cut1Name": "A",
-  "cut2Name": "B",
-  "cut3Name": "C",
-  "cut4Name": "D",
+  "cutoffs": {
+    "A": 90,
+    "B": 80,
+    "C": 70,
+    "D": 60
+  },
   "name": "Example Course",
   "categories": [
     {

--- a/packages/course-serializer/fixtures/v0-example-serialized-course.json
+++ b/packages/course-serializer/fixtures/v0-example-serialized-course.json
@@ -1,0 +1,91 @@
+{
+  "version": 0,
+  "year": 2020,
+  "credits": 0,
+  "cutoffs": {
+    "A": 90,
+    "B": 80,
+    "C": 70,
+    "D": 60
+  },
+  "name": "Example Course",
+  "categories": [
+    {
+      "isReallyCategory": true,
+      "droppedGrades": 0,
+      "numGrades": 20,
+      "weight": 0,
+      "name": "Attendance"
+    },
+    {
+      "isReallyCategory": true,
+      "droppedGrades": 0,
+      "numGrades": 13,
+      "weight": 1,
+      "name": "Online Quizzes"
+    },
+    {
+      "isReallyCategory": true,
+      "droppedGrades": 0,
+      "numGrades": 4,
+      "weight": 5,
+      "name": "Cultural Discourse Journal"
+    },
+    {
+      "isReallyCategory": false,
+      "droppedGrades": 0,
+      "numGrades": 1,
+      "weight": 20,
+      "name": "Exam 1"
+    },
+    {
+      "isReallyCategory": false,
+      "droppedGrades": 0,
+      "numGrades": 1,
+      "weight": 20,
+      "name": "Exam 2"
+    },
+    {
+      "isReallyCategory": false,
+      "droppedGrades": 0,
+      "numGrades": 1,
+      "weight": 5,
+      "name": "Initial Essay"
+    },
+    {
+      "isReallyCategory": false,
+      "droppedGrades": 0,
+      "numGrades": 1,
+      "weight": 15,
+      "name": "Final Essay"
+    },
+    {
+      "isReallyCategory": true,
+      "droppedGrades": 0,
+      "numGrades": 2,
+      "weight": 10,
+      "name": "Short Paper"
+    },
+    {
+      "isReallyCategory": false,
+      "droppedGrades": 0,
+      "numGrades": 1,
+      "weight": 5,
+      "name": "Participation"
+    },
+    {
+      "isReallyCategory": false,
+      "droppedGrades": 0,
+      "numGrades": 1,
+      "weight": 5,
+      "name": "Presentation"
+    },
+    {
+      "isReallyCategory": false,
+      "droppedGrades": 0,
+      "numGrades": 1,
+      "weight": 15,
+      "name": "Online Quizzes after dropped"
+    }
+  ]
+}

--- a/packages/course-serializer/package.json
+++ b/packages/course-serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gradebook/course-serializer",
-  "version": "0.1.0",
+  "version": "0.0.9",
   "description": "Utilities to make a course shareable via URLs",
   "keywords": [],
   "author": "Vikas Potluri <vikaspotluri123.github@gmail.com>",

--- a/packages/course-serializer/package.json
+++ b/packages/course-serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gradebook/course-serializer",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "description": "Utilities to make a course shareable via URLs",
   "keywords": [],
   "author": "Vikas Potluri <vikaspotluri123.github@gmail.com>",

--- a/packages/course-serializer/src/course-serializer.ts
+++ b/packages/course-serializer/src/course-serializer.ts
@@ -1,5 +1,5 @@
 import {Category as ICategory} from './interfaces/category';
-import {Course as ICourse} from './interfaces/course';
+import {Course as ICourse, Cutoffs as ICutoffs} from './interfaces/course';
 
 const COURSE_NAME = /^[a-z]{3,4}-\d{3,4}$/i;
 const CUTOFFS = new Set(['A+', 'A', 'A-', 'B+', 'B', 'B-', 'C+', 'C', 'C-', 'D+', 'D', 'D-']);
@@ -7,15 +7,24 @@ const CUTOFFS = new Set(['A+', 'A', 'A-', 'B+', 'B', 'B-', 'C+', 'C', 'C-', 'D+'
 const validCourseName = (name: string): boolean => COURSE_NAME.test(name);
 const validCategoryName = (name: string): boolean => name.length >= 1 && name.length <= 50;
 const validWeight = (weight: number): boolean => weight >= 0 && weight < 1000000;
-const validCut = (cut: number): boolean => cut >= 10 && cut <= 10000;
-const validCutName = (cutName: string): boolean => CUTOFFS.has(cutName);
 const validCredits = (credits: number): boolean => credits >= 0 && credits <= 5;
 const validNumberCategories = (categories: ICategory[]): boolean => categories.length >= 2;
 const validTotalGrades = (totalGrades: number): boolean => totalGrades >= 1 && totalGrades <= 40;
 const validDroppedGrades = (totalDropped: number, totalGrades: number): boolean =>
 	totalDropped >= 0 && totalGrades > totalDropped;
+const validCut = (cut: number): boolean => cut >= 10 && cut <= 10000;
+const validCutName = (cutName: string): boolean => CUTOFFS.has(cutName);
+const validCutoffs = (cutoffs: ICutoffs): boolean => {
+	for (const [cutName, cutValue] of Object.entries(cutoffs)) {
+		if (!validCutName(cutName) || !validCut(cutValue)) {
+			return false;
+		}
+	}
 
-export const EXPORT_VERSION = 0;
+	return true;
+};
+
+export const EXPORT_VERSION = 1;
 
 export function isomorphicAtoB(input: string): string {
 	// @ts-expect-error
@@ -54,14 +63,7 @@ export function _validateCategory(category: ICategory): boolean {
 export function validate(course: ICourse): boolean {
 	return (
 		validCourseName(course.name) &&
-		validCut(course.cut1) &&
-		validCut(course.cut2) &&
-		validCut(course.cut3) &&
-		validCut(course.cut4) &&
-		validCutName(course.cut1Name) &&
-		validCutName(course.cut2Name) &&
-		validCutName(course.cut3Name) &&
-		validCutName(course.cut4Name) &&
+		validCutoffs(course.cutoffs) &&
 		validCredits(course.credits) &&
 		validNumberCategories(course.categories) &&
 		course.categories.map(category => _validateCategory(category)).filter(t => !t).length > 0
@@ -89,14 +91,7 @@ export interface IUnsafeCategory {
 export interface IUnsafeCourse {
 	name: string;
 	credits: number;
-	cut1: number;
-	cut1Name: string;
-	cut2: number;
-	cut2Name: string;
-	cut3: number;
-	cut3Name: string;
-	cut4: number;
-	cut4Name: string;
+	cutoffs: ICutoffs;
 	semester?: string;
 	categories?: IUnsafeCategory[] | ICategory[];
 }
@@ -137,24 +132,23 @@ export function _serializeCategory(category: ICategory): string {
  * @description converts a course into a compressed stream that can be parsed
  * by _deserializeCourseMeta while adding some metadata
  *
- * Output format: {version}|{year}|{credits}|{cut1}|{cut2}|{cut3}|{cut4}|{name}
+ * Output format: {version}|{year}|{credits}|{numCutoffs}|({cut1Name},{cut1Value}|)[numCutoffs]|{name}
  *
  * Name goes last because it can contain pipes and there's no need to add
  * escaping on top of decoding
  */
 export function _serializeCourseMeta(course: ICourse): string {
 	let built = `${EXPORT_VERSION}|`;
+	const cutoffs = Object.entries(course.cutoffs);
 
 	built += new Date().getFullYear().toString() + '|';
 	built += `${course.credits}|`;
-	built += `${course.cut1}|`;
-	built += `${course.cut2}|`;
-	built += `${course.cut3}|`;
-	built += `${course.cut4}|`;
-	built += `${course.cut1Name}|`;
-	built += `${course.cut2Name}|`;
-	built += `${course.cut3Name}|`;
-	built += `${course.cut4Name}|`;
+	built += `${cutoffs.length}|`;
+
+	for (const [name, value] of cutoffs) {
+		built += `${name},${value}|`;
+	}
+
 	built += course.name;
 	return built;
 }
@@ -172,22 +166,43 @@ export function _deserializeCategory(category: string): ICategory {
 }
 
 export function _deserializeCourseMeta(course: string): ICourseWithMeta {
-	const [v, y, cr, a, b, c, d, e, f, g, h, ...n] = course.split('|'); // eslint-disable-line unicorn/prevent-abbreviations
+	let [
+		version,
+		year,
+		credits,
+		totalCutoffs,
+		...remaining
+	] = course.split('|');
+
+	let cutoffs: string[] = [];
+	let name = '';
+
+	if (version === '0') {
+		cutoffs.push(`${remaining[3]},${totalCutoffs}`);
+		cutoffs.push(`${remaining[4]},${remaining[0]}`);
+		cutoffs.push(`${remaining[5]},${remaining[1]}`);
+		cutoffs.push(`${remaining[6]},${remaining[2]}`);
+		name = remaining.slice(7).join('|');
+		totalCutoffs = '4';
+	} else if (version === '1') {
+		cutoffs = remaining.slice(0, Number(totalCutoffs));
+		name = remaining.slice(Number(totalCutoffs)).join('|');
+	}
 
 	return {
-		version: Number(v),
-		year: Number(y),
-		credits: Number(cr),
-		cut1: Number(a),
-		cut2: Number(b),
-		cut3: Number(c),
-		cut4: Number(d),
-		cut1Name: e,
-		cut2Name: f,
-		cut3Name: g,
-		cut4Name: h,
-		name: n.join('|'),
-		categories: null
+		version: Number(version),
+		year: Number(year),
+		credits: Number(credits),
+		name,
+		categories: null,
+		// Vikas wrote this code so blame him for using reduce :) He says it's the easiest
+		// way to transform an array to an object inline
+		// eslint-disable-next-line unicorn/no-reduce
+		cutoffs: cutoffs.reduce<{[s: string]: number}>((allCutoffs, currentCutoff) => {
+			const [name, value] = currentCutoff.split(',');
+			allCutoffs[name] = Number(value);
+			return allCutoffs;
+		}, {})
 	};
 }
 
@@ -208,14 +223,7 @@ export function strip(course: ICourse | IUnsafeCourse): ICourse {
 	return {
 		name: course.name,
 		credits: course.credits,
-		cut1: course.cut1,
-		cut2: course.cut2,
-		cut3: course.cut3,
-		cut4: course.cut4,
-		cut1Name: course.cut1Name,
-		cut2Name: course.cut2Name,
-		cut3Name: course.cut3Name,
-		cut4Name: course.cut4Name,
+		cutoffs: course.cutoffs,
 		// @ts-expect-error
 		categories: course.categories.map(category => _stripCategory(category))
 	};

--- a/packages/course-serializer/src/course-serializer.ts
+++ b/packages/course-serializer/src/course-serializer.ts
@@ -178,6 +178,8 @@ export function _deserializeCourseMeta(course: string): ICourseWithMeta {
 	let name = '';
 
 	if (version === '0') {
+		// Map v0 order to v1
+		// v0: {version}|{year}|{credits}|{cut1}|{cut2}|{cut3}|{cut4}|{cut1Name}|{cut2Name}|{cut3Name}|{cut4Name}|{name}
 		cutoffs.push(`${remaining[3]},${totalCutoffs}`);
 		cutoffs.push(`${remaining[4]},${remaining[0]}`);
 		cutoffs.push(`${remaining[5]},${remaining[1]}`);

--- a/packages/course-serializer/src/interfaces/course.ts
+++ b/packages/course-serializer/src/interfaces/course.ts
@@ -7,7 +7,7 @@ export interface Course {
 	categories: Category[];
 }
 
-export interface Cutoffs {
+export type Cutoffs = {
 	'A+'?: number;
 	A?: number;
 	'A-'?: number;

--- a/packages/course-serializer/src/interfaces/course.ts
+++ b/packages/course-serializer/src/interfaces/course.ts
@@ -1,6 +1,6 @@
 import {Category} from './category';
 
-export interface Course {
+export interface Iv0Course {
 	name: string;
 	credits: number;
 	cut1: number;
@@ -12,4 +12,26 @@ export interface Course {
 	cut4: number;
 	cut4Name: string;
 	categories: Category[];
+}
+
+export interface Course {
+	name: string;
+	credits: number;
+	cutoffs: Cutoffs;
+	categories: Category[];
+}
+
+export interface Cutoffs {
+	'A+'?: number;
+	A?: number;
+	'A-'?: number;
+	'B+'?: number;
+	B?: number;
+	'B-'?: number;
+	'C+'?: number;
+	C?: number;
+	'C-'?: number;
+	'D+'?: number;
+	D?: number;
+	'D-'?: number;
 }

--- a/packages/course-serializer/src/interfaces/course.ts
+++ b/packages/course-serializer/src/interfaces/course.ts
@@ -1,19 +1,5 @@
 import {Category} from './category';
 
-export interface Iv0Course {
-	name: string;
-	credits: number;
-	cut1: number;
-	cut1Name: string;
-	cut2: number;
-	cut2Name: string;
-	cut3: number;
-	cut3Name: string;
-	cut4: number;
-	cut4Name: string;
-	categories: Category[];
-}
-
 export interface Course {
 	name: string;
 	credits: number;

--- a/packages/course-serializer/src/interfaces/course.ts
+++ b/packages/course-serializer/src/interfaces/course.ts
@@ -20,4 +20,4 @@ export type Cutoffs = {
 	'D+'?: number;
 	D?: number;
 	'D-'?: number;
-}
+};


### PR DESCRIPTION
- Supports [client JSON Cutoffs](https://github.com/gradebook/client/pull/211) by migrating to the new course schema. 
- Adds a translation for v0 to ensure legacy support.
- Adds a regression test for v0 and updates tests for v1.


To test:

1. Pull utils and run `yarn link` in course-serializer
2. Pull corresponding client and server cutoff PRs
3. Run `yarn link @gradebook/course-serializer` in client
4. Test away!