### PR TITLE
✨ add support for selecting existing user when logging in

### DIFF
--- a/packages/core-developer-tools/package.json
+++ b/packages/core-developer-tools/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gradebook/core-developer-tools",
   "version": "0.1.3",
-  "description": "Now I’m the model of a modern major general / The venerated Virginian veteran whose men are all / Lining up, to put me up on a pedestal / Writin’ letters to relatives / Embellishin’ my elegance and eloquence / But the elephant is in the room / The truth is in ya face when ya hear the British cannons go / BOOM",
   "keywords": [],
   "author": "Vikas Potluri <vikaspotluri123.github@gmail.com>",
   "homepage": "https://github.com/gradebook/utils#readme",

--- a/packages/core-developer-tools/package.json
+++ b/packages/core-developer-tools/package.json
@@ -7,6 +7,7 @@
   "bugs": "https://github.com/gradebook/utils/issues",
   "license": "MIT",
   "main": "lib/core-developer-tools.js",
+  "type": "module",
   "directories": {
     "lib": "lib",
     "test": "__tests__"

--- a/packages/core-developer-tools/src/core-developer-tools.ts
+++ b/packages/core-developer-tools/src/core-developer-tools.ts
@@ -1,11 +1,17 @@
 import type {Application} from 'express';
 import {register as registerSentry} from './tools/sentry.js';
+import {register as registerAuth} from './tools/auth.js';
+import {serverDependencies} from './server-dependencies.js';
 
 if (process.env.NODE_ENV === 'production') {
 	console.error('Attempted to load @gradebook/core-developer-tools in a production environment');
 	process.exit(1); // eslint-disable-line unicorn/no-process-exit
 }
 
-export function load(serverRoot: string, app: Application) {
-	registerSentry(app);
+export async function load(serverRoot: string, app: Application) {
+	await serverDependencies.init(serverRoot);
+	await Promise.all([
+		registerSentry(app),
+		registerAuth(app),
+	]);
 }

--- a/packages/core-developer-tools/src/query.ts
+++ b/packages/core-developer-tools/src/query.ts
@@ -1,0 +1,11 @@
+import {URL, URLSearchParams} from 'url';
+import {Request} from 'express';
+
+export function getRequestUrl(request: Request) {
+	return new URL(request.originalUrl, request.headers.referer);
+}
+
+export function getQuery(query: URLSearchParams): string {
+	const stringifiedQuery = query.toString();
+	return stringifiedQuery ? `?${stringifiedQuery}` : stringifiedQuery;
+}

--- a/packages/core-developer-tools/src/query.ts
+++ b/packages/core-developer-tools/src/query.ts
@@ -2,7 +2,7 @@ import {URL, URLSearchParams} from 'url';
 import {Request} from 'express';
 
 export function getRequestUrl(request: Request) {
-	return new URL(request.originalUrl, request.headers.referer);
+	return new URL(request.originalUrl, request.headers.referer || `${request.protocol}://${request.headers.host}`);
 }
 
 export function getQuery(query: URLSearchParams): string {

--- a/packages/core-developer-tools/src/server-dependencies.ts
+++ b/packages/core-developer-tools/src/server-dependencies.ts
@@ -1,0 +1,24 @@
+import path from 'path';
+import type ExpressDependency from 'express';
+
+export class ServerDependencies {
+	public knex: any;
+	public express: typeof ExpressDependency;
+
+	private serverRoot: string;
+
+	async init(serverRoot: string) {
+		this.serverRoot = serverRoot;
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+		this.knex = await this.import<any>('./lib/database/knex.js');
+		this.express = await this.import<typeof ExpressDependency>('node_modules/express/index.js');
+	}
+
+	async import<T>(serverRelativePath: string): Promise<T> {
+		const absolutePath = path.resolve(this.serverRoot, serverRelativePath);
+
+		return import(absolutePath) as Promise<T>;
+	}
+}
+
+export const serverDependencies = new ServerDependencies();

--- a/packages/core-developer-tools/src/tools/auth.ts
+++ b/packages/core-developer-tools/src/tools/auth.ts
@@ -1,0 +1,190 @@
+import type {Application, NextFunction, Request, Response, RequestHandler} from 'express';
+import {serverDependencies} from '../server-dependencies.js';
+import {appPath} from '../_app-path.js';
+import * as query from '../query.js';
+
+const route = '/authentication/begin';
+
+async function getEmails() {
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+	const response = await serverDependencies.knex.getKnex().from('users').select('email').orderBy('updated_at', 'desc') as Array<{email: string}>;
+
+	return response.map(({email}) => email);
+}
+
+async function getId(email: string/* , table: string | null */): Promise<string | undefined> {
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+	const response = await serverDependencies.knex.getKnex()
+		.select('id')
+		.from('users')
+		.where('email', email)
+		.first() as undefined | {id: string};
+
+	if (response) {
+		return response.id;
+	}
+
+	return undefined;
+}
+
+const renderEmails = (emails: string[]) => {
+	let response = '';
+
+	for (const email of emails) {
+		response += `<li class="email"><a href="#">${email}</a></li>`;
+	}
+
+	return response;
+};
+
+const render = (emails: string[], routeQuery: string) => `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Developer Session Chooser</title>
+	<style>
+		body {
+			margin: 0;
+			font-family: sans-serif;
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			margin-top: 25vh;
+		}
+
+		.container {
+			margin: 0 auto;
+			max-width: 450px;
+		}
+
+		p {
+			margin: 0;
+			font-size: 1.25rem;
+		}
+
+		ul {
+			padding-left: 1.25rem;
+			margin-bottom: 2.5rem;
+		}
+
+		.emails {
+			display: flex;
+			flex-direction: column;
+		}
+
+		.email {
+			padding: 0.5rem 1rem;
+			margin: 0.2rem;
+		}
+
+		.email a {
+			cursor: pointer;
+		}
+
+		.email a:hover {
+			color: firebrick;
+			text-decoration: underline;
+		}
+	</style>
+</head>
+<body>
+	<div class="container">
+		<p>Choose an existing account in the database:</p>
+		<div class="emails">
+			<ul>
+				${renderEmails(emails)}
+			</ul>
+			<a href="${route}${routeQuery}">Use Google Auth</a>
+
+			<form name="selector" method="post" action="/__dev__/auth/session">
+				<input type="hidden" name="email" />
+			</form>
+		</div>
+	</div>
+	<script>
+		const form = document.querySelector('[name="selector"]');
+		const email = document.querySelector('input[name="email"]');
+		document.querySelectorAll('.email a').forEach(anchor => {
+			anchor.addEventListener('click', event => {
+				event.preventDefault();
+				email.value = event.target.textContent;
+				form.submit();
+			});
+		});
+	</script>
+</body>
+</html>
+`;
+
+async function interceptAuth(request: Request, response: Response, next: NextFunction) {
+	if (request.query.straightToGoogle) {
+		next();
+		return;
+	}
+
+	const emails = await getEmails();
+	const queryParameters = query.getRequestUrl(request).searchParams;
+	queryParameters.set('straightToGoogle', 'true');
+
+	response.status(200).send(render(emails, query.getQuery(queryParameters)));
+}
+
+async function useEmail(request: Request, response: Response) {
+	const table: string | null = null;
+	const id = await getId(request.body.email/* , table */);
+	if (!id) {
+		response.status(500).json({
+			error: `Email ${request.body.email} not found`,
+		});
+
+		return;
+	}
+
+	const session = (request as any).session as {
+		passport?: Record<string, any>;
+		save: (callback: (error: unknown) => any) => unknown;
+	};
+
+	if (session.passport) {
+		response.status(500).json({
+			error: 'Passport exists in session - this is unexpected',
+			passport: session.passport,
+		});
+
+		return;
+	}
+
+	session.passport = {
+		user: `${table}:${id}`,
+	};
+
+	session.save(error => {
+		if (error) {
+			response.status(500).json({
+				error: 'Unable to save session',
+				saveError: error,
+			});
+
+			return;
+		}
+
+		response.redirect('/assets/logged-in.html');
+	});
+}
+
+export async function register(app: Application) {
+	const withUser = await serverDependencies.import<{default: RequestHandler}>(
+		'./lib/controllers/authentication/with-user.js',
+	);
+
+	// @todo: hostmatching
+	app.get(route, interceptAuth);
+	app.post(
+		appPath('/auth/session'),
+		withUser.default,
+		serverDependencies.express.urlencoded({extended: false}),
+		useEmail,
+	);
+}

--- a/packages/core-developer-tools/src/tools/sentry.ts
+++ b/packages/core-developer-tools/src/tools/sentry.ts
@@ -1,8 +1,9 @@
 import path from 'path';
 import {readFile} from 'fs/promises';
-import {fileURLToPath, URL} from 'url';
+import {fileURLToPath} from 'url';
 import type {Application, NextFunction, Request, Response} from 'express';
 import {appPath} from '../_app-path.js';
+import * as query from '../query.js';
 
 const ERROR_PAGE_PATH = '/api/embed/error-page/';
 const ENVELOPE_PATH = '/api/\\d+/envelope/';
@@ -14,13 +15,12 @@ const errorPageSource = path.resolve(__dirname, './sentry-error-page.js');
 
 function hideKeys(keys: string[]) {
 	return (request: Request, response: Response, next: NextFunction) => {
-		const url = new URL(request.originalUrl, request.headers.referer);
+		const url = query.getRequestUrl(request);
 		for (const key of keys) {
 			url.searchParams.delete(key);
 		}
 
-		const query = url.searchParams.toString();
-		request.originalUrl = url.pathname + (query ? `?${query}` : '');
+		request.originalUrl = url.pathname + query.getQuery(url.searchParams);
 		next();
 	};
 }

--- a/packages/core-developer-tools/src/tools/sentry.ts
+++ b/packages/core-developer-tools/src/tools/sentry.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import {readFile} from 'fs/promises';
-import {URL} from 'url';
+import {fileURLToPath, URL} from 'url';
 import type {Application, NextFunction, Request, Response} from 'express';
 import {appPath} from '../_app-path.js';
 
@@ -9,6 +9,7 @@ const ENVELOPE_PATH = '/api/\\d+/envelope/';
 const STORE_PATH = '/api/\\d+/store';
 
 let errorPageMarkup: Buffer;
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const errorPageSource = path.resolve(__dirname, './sentry-error-page.js');
 
 function hideKeys(keys: string[]) {

--- a/packages/core-developer-tools/tsconfig.json
+++ b/packages/core-developer-tools/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig-esm.json",
   "include": [
     "src/",
     "__tests__/"


### PR DESCRIPTION
When developer mode is enabled, allows you to select a user without being logged in to that Google account, and also lists the associated accounts.

Use cases:
 - Not sure which accounts exist
 - local staging vs development
 - remote browsers (Edge + VSCode, Cypress)