### PR TITLE
Calculate semesters for server & client

### DIFF
--- a/packages/time/__tests__/semester.spec.js
+++ b/packages/time/__tests__/semester.spec.js
@@ -8,7 +8,7 @@ const {
 	isSummerAllowed,
 	isFallAllowed,
 	isWinterAllowed,
-	_getActiveSemester: getActiveSemester,
+	_getPrimarySemester,
 } = __testHelper();
 
 describe('Unit > Semester', function () {
@@ -46,20 +46,20 @@ describe('Unit > Semester', function () {
 		expect(isWinterAllowed(2, 1, 2021)).to.equal(null);
 	});
 
-	it('_getActiveSemester', function () {
-		expect(getActiveSemester(1, 1, 2020)).to.equal('2019W');
-		expect(getActiveSemester(1, 9, 2020)).to.equal('2019W');
-		expect(getActiveSemester(1, 10, 2020)).to.equal('2020S');
-		expect(getActiveSemester(1, 15, 2020)).to.equal('2020S');
-		expect(getActiveSemester(3, 15, 2020)).to.equal('2020S');
-		expect(getActiveSemester(5, 25, 2020)).to.equal('2020S');
-		expect(getActiveSemester(5, 26, 2020)).to.equal('2020U');
-		expect(getActiveSemester(7, 19, 2020)).to.equal('2020U');
-		expect(getActiveSemester(8, 10, 2020)).to.equal('2020U');
-		expect(getActiveSemester(8, 11, 2020)).to.equal('2020F');
-		expect(getActiveSemester(11, 11, 2020)).to.equal('2020F');
-		expect(getActiveSemester(12, 20, 2020)).to.equal('2020F');
-		expect(getActiveSemester(12, 21, 2020)).to.equal('2020W');
-		expect(getActiveSemester(12, 31, 2020)).to.equal('2020W');
+	it('_getPrimarySemester', function () {
+		expect(_getPrimarySemester(0, 1, 2020)).to.equal('2019W');
+		expect(_getPrimarySemester(0, 9, 2020)).to.equal('2019W');
+		expect(_getPrimarySemester(0, 10, 2020)).to.equal('2020S');
+		expect(_getPrimarySemester(0, 15, 2020)).to.equal('2020S');
+		expect(_getPrimarySemester(2, 15, 2020)).to.equal('2020S');
+		expect(_getPrimarySemester(4, 27, 2020)).to.equal('2020S');
+		expect(_getPrimarySemester(4, 28, 2020)).to.equal('2020U');
+		expect(_getPrimarySemester(6, 19, 2020)).to.equal('2020U');
+		expect(_getPrimarySemester(7, 16, 2020)).to.equal('2020U');
+		expect(_getPrimarySemester(7, 17, 2020)).to.equal('2020F');
+		expect(_getPrimarySemester(10, 11, 2020)).to.equal('2020F');
+		expect(_getPrimarySemester(11, 20, 2020)).to.equal('2020F');
+		expect(_getPrimarySemester(11, 21, 2020)).to.equal('2020W');
+		expect(_getPrimarySemester(11, 31, 2020)).to.equal('2020W');
 	});
 });

--- a/packages/time/__tests__/semester.spec.js
+++ b/packages/time/__tests__/semester.spec.js
@@ -4,46 +4,56 @@ import {expect} from 'chai';
 import {__testHelper} from '../lib/semester.js';
 
 const {
-	isSpringAllowed,
-	isSummerAllowed,
-	isFallAllowed,
-	isWinterAllowed,
+	getFallActiveRange,
+	getSpringActiveRange,
+	getSummerActiveRange,
+	getWinterActiveRange,
 	_getPrimarySemester,
+	isDateInActiveRange,
 } = __testHelper();
 
+const verifyDate = (candidate, year, month, day) => {
+	expect(candidate.getFullYear(), 'year').to.equal(year);
+	expect(candidate.getMonth(), 'month').to.equal(month);
+	expect(candidate.getDate(), 'day').to.equal(day);
+};
+
 describe('Unit > Semester', function () {
-	it('isSpringAllowed', function () {
-		expect(isSpringAllowed(12, 14, 2019)).to.equal(null);
-		expect(isSpringAllowed(12, 15, 2019)).to.equal('2020S');
-		expect(isSpringAllowed(1, 5, 2020)).to.equal('2020S');
-		expect(isSpringAllowed(3, 15, 2020)).to.equal('2020S');
-		expect(isSpringAllowed(6, 15, 2020)).to.equal('2020S');
-		expect(isSpringAllowed(6, 16, 2020)).to.equal(null);
+	it('getSpringActiveRange', function () {
+		verifyDate(getSpringActiveRange(2018).start, 2017, 10, 1);
+		verifyDate(getSpringActiveRange(2018).end, 2018, 5, 10);
 	});
 
-	it('isSummerAllowed', function () {
-		expect(isSummerAllowed(4, 30, 2020)).to.equal(null);
-		expect(isSummerAllowed(5, 1, 2020)).to.equal('2020U');
-		expect(isSummerAllowed(7, 15, 2020)).to.equal('2020U');
-		expect(isSummerAllowed(8, 31, 2020)).to.equal('2020U');
-		expect(isSummerAllowed(9, 1, 2020)).to.equal(null);
+	it('getSummerActiveRange', function () {
+		verifyDate(getSummerActiveRange(2018).start, 2018, 2, 25);
+		verifyDate(getSummerActiveRange(2018).end, 2018, 7, 31);
 	});
 
-	it('isFallAllowed', function () {
-		expect(isFallAllowed(7, 31, 2020)).to.equal(null);
-		expect(isFallAllowed(8, 1, 2020)).to.equal('2020F');
-		expect(isFallAllowed(10, 15, 2020)).to.equal('2020F');
-		expect(isFallAllowed(12, 28, 2020)).to.equal('2020F');
-		expect(isFallAllowed(12, 29, 2020)).to.equal(null);
+	it('getFallActiveRange', function () {
+		verifyDate(getFallActiveRange(2018).start, 2018, 2, 25);
+		verifyDate(getFallActiveRange(2018).end, 2018, 11, 31);
 	});
 
-	it('isWinterAllowed', function () {
-		expect(isWinterAllowed(11, 30, 2020)).to.equal(null);
-		expect(isWinterAllowed(12, 1, 2020)).to.equal('2020W');
-		expect(isWinterAllowed(12, 25, 2020)).to.equal('2020W');
-		expect(isWinterAllowed(1, 15, 2021)).to.equal('2020W');
-		expect(isWinterAllowed(1, 31, 2021)).to.equal('2020W');
-		expect(isWinterAllowed(2, 1, 2021)).to.equal(null);
+	it('getWinterActiveRange', function () {
+		verifyDate(getWinterActiveRange(2018).start, 2018, 10, 1);
+		verifyDate(getWinterActiveRange(2018).end, 2019, 0, 20);
+	});
+
+	it('isDateInActiveRange', function () {
+		const dec1 = new Date(2017, 11, 1);
+		const dec20 = new Date(2017, 11, 20);
+		const dec31 = new Date(2017, 11, 31);
+		const jan1 = new Date(2018, 0, 1);
+		const feb1 = new Date(2018, 1, 1);
+
+		expect(isDateInActiveRange(dec1, dec31, dec20)).to.be.true;
+		expect(isDateInActiveRange(dec20, dec31, dec1)).to.be.false;
+		expect(isDateInActiveRange(dec1, dec31, dec1)).to.be.true;
+		expect(isDateInActiveRange(dec1, dec31, dec31)).to.be.true;
+		expect(isDateInActiveRange(dec20, jan1, dec31)).to.be.true;
+		expect(isDateInActiveRange(dec20, dec31, jan1)).to.be.false;
+		expect(isDateInActiveRange(dec20, jan1, feb1)).to.be.false;
+		expect(isDateInActiveRange(jan1, feb1, dec31)).to.be.false;
 	});
 
 	it('_getPrimarySemester', function () {

--- a/packages/time/__tests__/semester.spec.js
+++ b/packages/time/__tests__/semester.spec.js
@@ -1,14 +1,15 @@
 // @ts-check
-const rewire = require('rewire');
-const {expect} = require('chai');
+import {expect} from 'chai';
 
-const semester = rewire('../lib/semester');
+import {__testHelper} from '../lib/semester.js';
 
-const isSpringAllowed = semester.__get__('isSpringAllowed');
-const isSummerAllowed = semester.__get__('isSummerAllowed');
-const isFallAllowed = semester.__get__('isFallAllowed');
-const isWinterAllowed = semester.__get__('isWinterAllowed');
-const getActiveSemester = semester.__get__('_getActiveSemester');
+const {
+	isSpringAllowed,
+	isSummerAllowed,
+	isFallAllowed,
+	isWinterAllowed,
+	_getActiveSemester: getActiveSemester,
+} = __testHelper();
 
 describe('Unit > Semester', function () {
 	it('isSpringAllowed', function () {

--- a/packages/time/__tests__/units-to-ms.spec.js
+++ b/packages/time/__tests__/units-to-ms.spec.js
@@ -1,7 +1,7 @@
 // @ts-check
 
-const {expect} = require('chai');
-const {unitsToMs} = require('../lib/units-to-ms.js');
+import {expect} from 'chai';
+import {unitsToMs} from '../lib/units-to-ms.js';
 
 const assert = (timeString, expectation) => expect(unitsToMs(timeString)).to.equal(expectation);
 

--- a/packages/time/package.json
+++ b/packages/time/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://github.com/gradebook/utils#readme",
   "bugs": "https://github.com/gradebook/utils/issues",
   "license": "MIT",
+  "type": "module",
   "main": "lib/index.js",
   "directories": {
     "lib": "lib",

--- a/packages/time/src/browser.ts
+++ b/packages/time/src/browser.ts
@@ -1,4 +1,4 @@
-import dayjs from 'dayjs';
+import dayjs from 'dayjs/esm/index.js';
 import cpf from 'dayjs/plugin/customParseFormat.js';
 
 dayjs.extend(cpf);
@@ -7,4 +7,4 @@ export * as semester from './semester.js';
 export * as tzOffset from './tz-offset.js';
 export {default as unitsToMs} from './units-to-ms.js';
 
-export {default as dayjs} from 'dayjs';
+export {default as dayjs} from 'dayjs/esm/index.js';

--- a/packages/time/src/index.ts
+++ b/packages/time/src/index.ts
@@ -1,4 +1,4 @@
-import dayjs from 'dayjs';
+import dayjs from 'dayjs/esm/index.js';
 import cpf from 'dayjs/plugin/customParseFormat.js';
 
 dayjs.extend(cpf);
@@ -7,4 +7,4 @@ export * as semester from './semester.js';
 export * as tzOffset from './tz-offset.js';
 export {default as unitsToMs} from './units-to-ms.js';
 
-export {default as dayjs} from 'dayjs';
+export {default as dayjs} from 'dayjs/esm/index.js';

--- a/packages/time/src/index.ts
+++ b/packages/time/src/index.ts
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import cpf from 'dayjs/plugin/customParseFormat';
+import cpf from 'dayjs/plugin/customParseFormat.js';
 
 dayjs.extend(cpf);
 

--- a/packages/time/src/semester.ts
+++ b/packages/time/src/semester.ts
@@ -7,12 +7,12 @@ const AUGUST = 8;
 const DECEMBER = 12;
 
 type CurrentSemesterState = {
-	activeSemester: string;
+	primarySemester: string;
 	allowedSemesters: string[];
 };
 
 export const data: CurrentSemesterState = {
-	activeSemester: null,
+	primarySemester: null,
 	allowedSemesters: [],
 };
 
@@ -57,25 +57,28 @@ const isWinterAllowed: SemesterAllowedFunction = (currentMonth, currentDay, curr
 };
 
 /**
- * Compute the active semester
+ * Compute the primary semester
  *
- * Semester Timelines:
+ * Primary semester timeline:
  *
- * January 10 - May 25 = Spring;
- * May 26 - August 10 = Summer;
- * August 11 - December 20 = Fall;
+ * January 10 - May 27 = Spring;
+ *
+ * May 28 - August 17 = Summer;
+ *
+ * August 17 - December 20 = Fall;
+ *
  * December 21 - January 09 = Winter;
  */
-function _getActiveSemester(currentMonth: number, currentDay: number, currentYear: number): string {
+function _getPrimarySemester(currentMonth: number, currentDay: number, currentYear: number): string {
 	// CASE: January to May
-	if (currentMonth >= JANUARY && currentMonth <= MAY) {
-		// CASE: Before January 15 -> Winter of LAST year
+	if (currentMonth <= MAY) {
+		// CASE: Before January 10 -> Winter of LAST year
 		if (currentMonth === JANUARY && currentDay < 10) {
 			return `${currentYear - 1}W`;
 		}
 
-		// CASE: After May 25 -> Summer
-		if (currentMonth === MAY && currentDay > 25) {
+		// CASE: After May 27 -> Summer
+		if (currentMonth === MAY && currentDay > 27) {
 			return `${currentYear}U`;
 		}
 
@@ -85,12 +88,12 @@ function _getActiveSemester(currentMonth: number, currentDay: number, currentYea
 
 	// CASE: Up to August
 	if (currentMonth <= AUGUST) {
-		// CASE: AFTER August 10 -> Fall
-		if (currentMonth === AUGUST && currentDay > 10) {
+		// CASE: AFTER August 16 -> Fall
+		if (currentMonth === AUGUST && currentDay > 16) {
 			return `${currentYear}F`;
 		}
 
-		// CASE: BEFORE (or on) August 10 -> Summer
+		// CASE: BEFORE (or on) August 16 -> Summer
 		return `${currentYear}U`;
 	}
 
@@ -114,13 +117,7 @@ export function computeSemesterData() {
 	const currentMonth = currentDate.getMonth() + 1;
 	const currentDay = currentDate.getDate();
 
-	data.activeSemester = _getActiveSemester(currentMonth, currentDay, currentYear);
-	data.allowedSemesters = [
-		isWinterAllowed(currentMonth, currentDay, currentYear),
-		isSpringAllowed(currentMonth, currentDay, currentYear),
-		isSummerAllowed(currentMonth, currentDay, currentYear),
-		isFallAllowed(currentMonth, currentDay, currentYear),
-	].filter(Boolean);
+	data.primarySemester = _getPrimarySemester(currentMonth, currentDay, currentYear);
 }
 
 computeSemesterData();
@@ -133,6 +130,6 @@ export function __testHelper() {
 		isSummerAllowed,
 		isFallAllowed,
 		isWinterAllowed,
-		_getActiveSemester,
+		_getPrimarySemester,
 	};
 }

--- a/packages/time/src/semester.ts
+++ b/packages/time/src/semester.ts
@@ -126,3 +126,13 @@ export function computeSemesterData() {
 computeSemesterData();
 
 export default data;
+
+export function __testHelper() {
+	return {
+		isSpringAllowed,
+		isSummerAllowed,
+		isFallAllowed,
+		isWinterAllowed,
+		_getActiveSemester,
+	};
+}

--- a/packages/time/tsconfig.json
+++ b/packages/time/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig-esm.json",
   "include": [
     "src/",
     "__tests__/"


### PR DESCRIPTION
Provides semester lists for both client (active) and server (allowed) by using the client dates as a source of truth and programmatically adjusting the dates to get wider ranges for server. Server and client PRs will follow. 

Server will consider semesters allowed for 1 day prior to them becoming allowed in client, and for 7 days after they are no longer active in client. 

Other changes:
- Adjusts the schedules with the current changes from the [client PR](https://github.com/gradebook/client/pull/410) that this PR replaces. 
- Renames active => primary semester.
- Migrates to esm to keep tests happy.

Co-authored-by: Vikas Potluri <vikaspotluri123.github@gmail.com>

Meta
- 2 reviewers please, time is hard and prone to errors
- Rebase
- Will have minor version bump to 0.1.0